### PR TITLE
added values and returns to performance output

### DIFF
--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -51,6 +51,8 @@ pub struct PerfStruct {
     pub vol: f64,
     pub mdd: f64,
     pub sharpe: f64,
+    pub values: Vec<f64>,
+    pub returns: Vec<f64>,
 }
 
 impl PortfolioPerformance {
@@ -60,7 +62,17 @@ impl PortfolioPerformance {
             vol: self.get_vol(),
             mdd: self.get_maxdd(),
             sharpe: self.get_sharpe(),
+            values: self.get_values(),
+            returns: self.get_returns(),
         }
+    }
+
+    fn get_values(&self) -> Vec<f64> {
+        self.values.get_values()
+    }
+
+    fn get_returns(&self) -> Vec<f64> {
+        self.values.pct_change()
     }
 
     fn get_vol(&self) -> f64 {

--- a/src/series/mod.rs
+++ b/src/series/mod.rs
@@ -7,6 +7,10 @@ pub struct TimeSeries {
 }
 
 impl TimeSeries {
+    pub fn get_values(&self) -> Vec<f64> {
+        self.values.clone()
+    }
+
     pub fn pct_change_log(&self) -> Vec<f64> {
         let mut res: Vec<f64> = Vec::new();
         let mut temp = &self.values[0];

--- a/src/simcontext/mod.rs
+++ b/src/simcontext/mod.rs
@@ -16,9 +16,9 @@ impl SimContext {
         }
     }
 
-    pub fn calculate_perf(&mut self) -> (f64, f64, f64, f64) {
+    pub fn calculate_perf(&mut self) -> (f64, f64, f64, f64, Vec<f64>, Vec<f64>, Vec<i64>) {
         let perf = self.strat.get_perf();
-        (perf.ret, perf.vol, perf.mdd, perf.sharpe)
+        (perf.ret, perf.vol, perf.mdd, perf.sharpe, perf.values, perf.returns, self.sim_dates.clone())
     }
 
     pub fn new<T: Into<Box<dyn Strategy>>>(


### PR DESCRIPTION
During the last commit, there was a regression in the performance output. I think this is could be due to unpushed changes that were in pytho but this unifies the performance output of simulations across libraries.