### PR TITLE
18 perf stats

### DIFF
--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -19,6 +19,7 @@ pub struct BacktestOutput {
     pub dd_end_date: i64,
     pub best_return: f64,
     pub worst_return: f64,
+    pub frequency: String,
 }
 
 struct CalculationAlgos;
@@ -221,6 +222,7 @@ impl PerformanceCalculator {
             dd_end_date,
             best_return,
             worst_return,
+            frequency: freq.to_str(),
         }
     }
 }

--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -1,5 +1,18 @@
-use crate::types::{BacktestOutput, Frequency, StrategySnapshot};
+use crate::types::{Frequency, StrategySnapshot};
 use itertools::Itertools;
+
+///Performance output from a single backtest run.
+#[derive(Clone, Debug)]
+pub struct BacktestOutput {
+    pub ret: f64,
+    pub cagr: f64,
+    pub vol: f64,
+    pub mdd: f64,
+    pub sharpe: f64,
+    pub values: Vec<f64>,
+    pub returns: Vec<f64>,
+    pub dates: Vec<i64>,
+}
 
 struct CalculationAlgos;
 

--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -12,30 +12,45 @@ pub struct BacktestOutput {
     pub values: Vec<f64>,
     pub returns: Vec<f64>,
     pub dates: Vec<i64>,
+    pub cash_flows: Vec<f64>,
+    pub first_date: i64,
+    pub last_date: i64,
+    pub dd_start_date: i64,
+    pub dd_end_date: i64,
+    pub best_return: f64,
+    pub worst_return: f64,
 }
 
 struct CalculationAlgos;
 
 impl CalculationAlgos {
-    fn maxdd(values: &Vec<f64>) -> f64 {
+    ///Returns a tuple containing (max drawdown, position of drawdown start, end position)
+    fn maxdd(values: &Vec<f64>) -> (f64, usize, usize) {
         let mut maxdd = 0.0;
         let mut peak = 0.0;
+        let mut peak_pos: usize = 0;
         let mut trough = 0.0;
+        let mut trough_pos: usize = 0;
         let mut t2;
+        let mut pos: usize = 0;
 
         for t1 in values {
             if t1 > &peak {
                 peak = *t1;
+                peak_pos = pos.clone();
                 trough = peak;
+                trough_pos = peak_pos.clone();
             } else if t1 < &trough {
                 trough = *t1;
+                trough_pos = pos.clone();
                 t2 = (trough / peak) - 1.0;
                 if t2 < maxdd {
                     maxdd = t2
                 }
             }
+            pos += 1;
         }
-        maxdd
+        (maxdd, peak_pos, trough_pos)
     }
 
     fn var(values: &Vec<f64>) -> f64 {
@@ -82,23 +97,19 @@ impl PortfolioCalculations {
         }
     }
 
-    fn get_vol(portfolio_values: &Vec<f64>, cash_flows: &[f64], freq: &Frequency) -> f64 {
-        let rets =
-            PortfolioCalculations::get_returns_with_cashflows(portfolio_values, cash_flows, false);
+    fn get_vol(rets: &Vec<f64>, freq: &Frequency) -> f64 {
         let vol = CalculationAlgos::vol(&rets);
         PortfolioCalculations::annualize_volatility(vol, freq)
     }
 
-    fn get_sharpe(portfolio_values: &Vec<f64>, cash_flows: &[f64], freq: &Frequency) -> f64 {
-        let vol = PortfolioCalculations::get_vol(portfolio_values, cash_flows, freq);
-        let ret = PortfolioCalculations::get_portfolio_return(portfolio_values, cash_flows);
+    fn get_sharpe(rets: &Vec<f64>, log_rets: &Vec<f64>, days: i32, freq: &Frequency) -> f64 {
+        let vol = PortfolioCalculations::get_vol(rets, freq);
+        let ret = PortfolioCalculations::get_cagr(log_rets, days, freq);
         ret / vol
     }
 
-    fn get_maxdd(portfolio_values: &Vec<f64>, cash_flows: &[f64]) -> f64 {
+    fn get_maxdd(rets: &Vec<f64>) -> (f64, usize, usize) {
         //Adds N to the runtime, can run faster but it isn't worth the time atm
-        let rets =
-            PortfolioCalculations::get_returns_with_cashflows(portfolio_values, cash_flows, false);
         let mut values_with_cashflows = vec![100_000.0];
         for i in rets {
             //Because we add one value on creation, we can always unwrap safely
@@ -109,24 +120,17 @@ impl PortfolioCalculations {
         CalculationAlgos::maxdd(&values_with_cashflows)
     }
 
-    fn get_cagr(portfolio_values: &Vec<f64>, cash_flows: &[f64], freq: &Frequency) -> f64 {
-        let ret = PortfolioCalculations::get_portfolio_return(portfolio_values, cash_flows);
-        let days = portfolio_values.len() as i32;
+    fn get_cagr(log_rets: &Vec<f64>, days: i32, freq: &Frequency) -> f64 {
+        let ret = PortfolioCalculations::get_portfolio_return(log_rets);
         PortfolioCalculations::annualize_returns(ret, days, freq)
     }
 
-    fn get_portfolio_return(portfolio_values: &Vec<f64>, cash_flows: &[f64]) -> f64 {
-        let log_rets =
-            PortfolioCalculations::get_returns_with_cashflows(portfolio_values, cash_flows, true);
+    fn get_portfolio_return(log_rets: &Vec<f64>) -> f64 {
         let sum_log_rets: f64 = log_rets.iter().sum();
         sum_log_rets.exp() - 1.0
     }
 
-    fn get_returns_with_cashflows(
-        portfolio_values: &Vec<f64>,
-        cash_flows: &[f64],
-        is_log: bool,
-    ) -> Vec<f64> {
+    fn get_returns(portfolio_values: &Vec<f64>, cash_flows: &[f64], is_log: bool) -> Vec<f64> {
         let count = portfolio_values.len();
         let mut rets: Vec<f64> = Vec::new();
 
@@ -137,7 +141,7 @@ impl PortfolioCalculations {
 
                 let cash_flow = cash_flows.get(i).unwrap();
 
-                let gain = end - start - *cash_flow;
+                let gain = end - (start + *cash_flow);
                 let capital = start + *cash_flow;
                 let ret = gain / capital;
                 if is_log {
@@ -165,6 +169,7 @@ impl PerformanceCalculator {
         let mut dates: Vec<i64> = Vec::new();
         let mut total_values: Vec<f64> = Vec::new();
         cash_flows.push(0.0);
+
         for i in 0..states.len() {
             dates.push(*states.get(i).unwrap().date);
             total_values.push(*states.get(i).unwrap().portfolio_value);
@@ -175,19 +180,47 @@ impl PerformanceCalculator {
                 cash_flows.push(diff)
             }
         }
+
+        let returns = PortfolioCalculations::get_returns(&total_values, &cash_flows, false);
+
+        let log_returns = PortfolioCalculations::get_returns(&total_values, &cash_flows, true);
+
+        let (mdd, drawdown_start_pos, drawdown_end_pos) =
+            PortfolioCalculations::get_maxdd(&returns);
+        //This can error but shouldn't because we are querying into the same-length array
+        let dd_start_date = dates[drawdown_start_pos];
+        let dd_end_date = dates[drawdown_end_pos];
+
+        let best_return = *returns
+            .iter()
+            .min_by(|x, y| x.partial_cmp(y).unwrap())
+            .unwrap();
+        let worst_return = *returns
+            .iter()
+            .max_by(|x, y| x.partial_cmp(y).unwrap())
+            .unwrap();
+
         BacktestOutput {
-            ret: PortfolioCalculations::get_portfolio_return(&total_values, &cash_flows),
-            cagr: PortfolioCalculations::get_cagr(&total_values, &cash_flows, &freq),
-            vol: PortfolioCalculations::get_vol(&total_values, &cash_flows, &freq),
-            mdd: PortfolioCalculations::get_maxdd(&total_values, &cash_flows),
-            sharpe: PortfolioCalculations::get_sharpe(&total_values, &cash_flows, &freq),
-            values: total_values.clone(),
-            returns: PortfolioCalculations::get_returns_with_cashflows(
-                &total_values,
-                &cash_flows,
-                false,
+            ret: PortfolioCalculations::get_portfolio_return(&log_returns),
+            cagr: PortfolioCalculations::get_cagr(&log_returns, dates.len() as i32, &freq),
+            vol: PortfolioCalculations::get_vol(&returns, &freq),
+            mdd,
+            sharpe: PortfolioCalculations::get_sharpe(
+                &returns,
+                &log_returns,
+                dates.len() as i32,
+                &freq,
             ),
+            values: total_values.clone(),
+            returns,
             dates: dates.clone(),
+            cash_flows,
+            first_date: dates.first().unwrap().clone(),
+            last_date: dates.last().unwrap().clone(),
+            dd_start_date,
+            dd_end_date,
+            best_return,
+            worst_return,
         }
     }
 }
@@ -288,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn test_that_portfolio_calculates_performance_accuratelj() {
+    fn test_that_portfolio_calculates_performance_accurately() {
         let (brkr, clock) = setup();
         //We use less than 100% because some bugs become possible when you are allocating the full
         //portfolio which perturb the order of operations leading to different perf outputs.
@@ -342,10 +375,15 @@ mod tests {
         };
         let snap2 = StrategySnapshot {
             date: 102.into(),
-            portfolio_value: 144.1.into(),
-            net_cash_flow: 20.0.into(),
+            portfolio_value: 126.9.into(),
+            net_cash_flow: 30.0.into(),
         };
-        let with_cash_flows = vec![snap0, snap1, snap2];
+        let snap3 = StrategySnapshot {
+            date: 103.into(),
+            portfolio_value: 150.59.into(),
+            net_cash_flow: 40.0.into(),
+        };
+        let with_cash_flows = vec![snap0, snap1, snap2, snap3];
 
         let snap3 = StrategySnapshot {
             date: 100.into(),
@@ -359,10 +397,15 @@ mod tests {
         };
         let snap5 = StrategySnapshot {
             date: 102.into(),
-            portfolio_value: 121.0.into(),
+            portfolio_value: 99.0.into(),
             net_cash_flow: 0.0.into(),
         };
-        let without_cash_flows = vec![snap3, snap4, snap5];
+        let snap6 = StrategySnapshot {
+            date: 103.into(),
+            portfolio_value: 108.9.into(),
+            net_cash_flow: 0.0.into(),
+        };
+        let without_cash_flows = vec![snap3, snap4, snap5, snap6];
 
         let perf0 = PerformanceCalculator::calculate(Frequency::Yearly, with_cash_flows);
         let perf1 = PerformanceCalculator::calculate(Frequency::Yearly, without_cash_flows);
@@ -370,8 +413,8 @@ mod tests {
         let ret0 = f64::round(perf0.ret * 100.0);
         let ret1 = f64::round(perf1.ret * 100.0);
 
-        println!("{:?}", ret0);
-        println!("{:?}", ret1);
+        println!("{:?}", perf0);
+        println!("{:?}", perf1);
         assert_eq!(ret0, ret1);
     }
 }

--- a/src/simcontext/mod.rs
+++ b/src/simcontext/mod.rs
@@ -1,7 +1,7 @@
 use crate::clock::Clock;
-use crate::perf::PerformanceCalculator;
+use crate::perf::{BacktestOutput, PerformanceCalculator};
 use crate::strategy::{History, Strategy};
-use crate::types::{BacktestOutput, CashValue, Frequency};
+use crate::types::{CashValue, Frequency};
 
 ///Provides context for a single run of a simulation. Once a run has started, all communication
 ///with the components of a simulation should happen through this context.

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -142,10 +142,13 @@ pub struct StaticWeightStrategy<T: DataSource> {
 
 impl<T: DataSource> StaticWeightStrategy<T> {
     pub fn get_snapshot(&mut self) -> StrategySnapshot {
+        // Defaults to zero inflation because most users probably aren't looking
+        // for real returns calcs
         StrategySnapshot {
             date: self.clock.borrow().now(),
             portfolio_value: self.brkr.get_total_value(),
             net_cash_flow: self.net_cash_flow.clone(),
+            inflation: 0.0,
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -370,6 +370,17 @@ pub enum Frequency {
     Yearly,
 }
 
+impl Frequency {
+    pub fn to_str(&self) -> String {
+        match self {
+            Self::Second => String::from("Second"),
+            Self::Daily => String::from("Daily"),
+            Self::Monthly => String::from("Monthly"),
+            Self::Yearly => String::from("Yearly"),
+        }
+    }
+}
+
 ///A point=in-time representation of the current state of a strategy. These statistics are currently
 ///recorded for use within performance calculations after the simulation has concluded. They are
 ///distinct from the transaction logging performed by brokers.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -381,15 +381,44 @@ impl Frequency {
     }
 }
 
-///A point=in-time representation of the current state of a strategy. These statistics are currently
-///recorded for use within performance calculations after the simulation has concluded. They are
-///distinct from the transaction logging performed by brokers.
+/// A point=in-time representation of the current state of a strategy. These statistics are currently
+/// recorded for use within performance calculations after the simulation has concluded. They are
+/// distinct from the transaction logging performed by brokers.
 ///
-///net_cash_flow variable is a sum, not a measure of flow within the period. To get flows, we have
-///to diff each value with the previous one.
+/// Inflation is calculated over the snapshot period. No manipulation of the value is conducted to
+/// change the frequency.
+///
+/// net_cash_flow variable is a sum, not a measure of flow within the period. To get flows, we have
+/// to diff each value with the previous one.
 #[derive(Clone, Debug)]
 pub struct StrategySnapshot {
     pub date: DateTime,
     pub portfolio_value: CashValue,
     pub net_cash_flow: CashValue,
+    pub inflation: f64,
+}
+
+impl StrategySnapshot {
+    pub fn nominal(date: DateTime, portfolio_value: CashValue, net_cash_flow: CashValue) -> Self {
+        Self {
+            date,
+            portfolio_value,
+            net_cash_flow,
+            inflation: 0.0,
+        }
+    }
+
+    pub fn real(
+        date: DateTime,
+        portfolio_value: CashValue,
+        net_cash_flow: CashValue,
+        inflation: f64,
+    ) -> Self {
+        Self {
+            date,
+            portfolio_value,
+            net_cash_flow,
+            inflation,
+        }
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
-use std::{collections::HashMap, ops::Add};
 use std::hash::Hash;
 use std::ops::Deref;
+use std::{collections::HashMap, ops::Add};
 use time::{format_description, Date, OffsetDateTime};
 
 ///Defines a set of base types that are used by multiple components.
@@ -381,17 +381,4 @@ pub struct StrategySnapshot {
     pub date: DateTime,
     pub portfolio_value: CashValue,
     pub net_cash_flow: CashValue,
-}
-
-///Performance output from a single backtest run.
-#[derive(Clone, Debug)]
-pub struct BacktestOutput {
-    pub ret: f64,
-    pub cagr: f64,
-    pub vol: f64,
-    pub mdd: f64,
-    pub sharpe: f64,
-    pub values: Vec<f64>,
-    pub returns: Vec<f64>,
-    pub dates: Vec<i64>,
 }

--- a/tests/binance_test.rs
+++ b/tests/binance_test.rs
@@ -219,6 +219,7 @@ impl Strategy for MovingAverageStrategy {
             date: self.clock.borrow().now(),
             portfolio_value: val.clone(),
             net_cash_flow: CashValue::from(0.0),
+            inflation: 0.0,
         };
 
         self.history.push(snap);


### PR DESCRIPTION
Adds dates, drawdown timings, best and worst return, and frequency string to `BacktestOutput`.

Added tests, fmt, and cleaned up the perf calculation code for less repeated operations.