### PR TITLE
feat(clock): Add method to get length of clock

### DIFF
--- a/benches/sim_benchmark.rs
+++ b/benches/sim_benchmark.rs
@@ -25,7 +25,8 @@ pub fn full_backtest_random_data() {
         .build();
 
     let initial_cash: CashValue = 100_000.0.into();
-    let mut raw_data: HashMap<DateTime, Vec<Quote>> = HashMap::new();
+
+    let mut raw_data: HashMap<DateTime, Vec<Quote>> = HashMap::with_capacity(clock.borrow().len());
     for date in clock.borrow().peek() {
         let q1 = Quote::new(
             price_dist.sample(&mut rng),

--- a/src/clock/mod.rs
+++ b/src/clock/mod.rs
@@ -45,6 +45,11 @@ impl ClockInner {
     pub fn peek(&self) -> IntoIter<DateTime> {
         self.dates.clone().into_iter()
     }
+
+    // Get length of clock
+    pub fn len(&self) -> usize {
+        self.dates.len()
+    }
 }
 
 pub struct ClockBuilder {

--- a/src/clock/mod.rs
+++ b/src/clock/mod.rs
@@ -46,9 +46,14 @@ impl ClockInner {
         self.dates.clone().into_iter()
     }
 
-    // Get length of clock
+    /// Get length of clock
     pub fn len(&self) -> usize {
         self.dates.len()
+    }
+
+    /// Check to see if dates are empty
+    pub fn is_empty(&self) -> bool {
+        self.dates.is_empty()
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -109,7 +109,7 @@ pub fn fake_data_generator(clock: Clock) -> HashMapInput {
     let price_dist = Uniform::new(90.0, 100.0);
     let mut rng = thread_rng();
 
-    let mut raw_data: HashMap<DateTime, Vec<Quote>> = HashMap::new();
+    let mut raw_data: HashMap<DateTime, Vec<Quote>> = HashMap::with_capacity(clock.borrow().len());
     for date in clock.borrow().peek() {
         let q1 = Quote::new(
             price_dist.sample(&mut rng),


### PR DESCRIPTION
Should enable pre-allocation of hashmaps on creations, allowing speedups all across the board.
Benchmark had a small perf increase. 